### PR TITLE
Fix #22 - commands not focusing/activating

### DIFF
--- a/src/leaf.ts
+++ b/src/leaf.ts
@@ -122,7 +122,7 @@ export class HoverLeaf extends WorkspaceLeaf {
       this.opening = false;
     }
     this.view.iconEl.replaceWith(this.pinEl);
-    if (openState.state.mode === "source") {
+    if (openState.state?.mode === "source" || openState.eState) {
       setTimeout(() => {
         if (this.detaching) return;
         this.view?.setEphemeralState(openState.eState);
@@ -167,9 +167,14 @@ export class HoverLeaf extends WorkspaceLeaf {
   //   await super.setViewState(viewState, eState);
   // }
 
-  // setEphemeralState(state: any) {
-  //   super.setEphemeralState(state);
-  // }
+  setEphemeralState(state: any) {
+     super.setEphemeralState(state);
+     if (state.focus && this.view?.getViewType() === "empty") {
+       // Force empty (no-file) view to have focus so dialogs don't reset active pane
+       this.view.contentEl.tabIndex = -1;
+       this.view.contentEl.focus();
+     }
+  }
 
   detach() {
     if (this.opening) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -230,10 +230,9 @@ export default class HoverEditorPlugin extends Plugin {
       id: "open-new-popover",
       name: "Open new popover",
       callback: () => {
-        let popover = this.spawnPopover();
+        // Focus the leaf after it's shown
+        let popover = this.spawnPopover(undefined, () => this.app.workspace.setActiveLeaf(popover.leaf, false, true));
         popover.leaf.togglePin(true);
-        // TODO: focus doesn't seem to work on empty panes
-        this.app.workspace.setActiveLeaf(popover.leaf, false, true);
       },
     });
     this.addCommand({
@@ -247,7 +246,7 @@ export default class HoverEditorPlugin extends Plugin {
             if (token?.type === "internal-link") {
               let popover = this.spawnPopover();
               popover.leaf.togglePin(true);
-              popover.leaf.openLink(token.text, activeView.file.path);
+              popover.leaf.openLinkText(token.text, activeView.file.path, {active: true, eState: {focus: true}});
             }
           }
           return true;
@@ -264,7 +263,7 @@ export default class HoverEditorPlugin extends Plugin {
           if (!checking) {
             let popover = this.spawnPopover();
             popover.leaf.togglePin(true);
-            popover.leaf.openFile(activeView.file);
+            popover.leaf.openFile(activeView.file, {active: true, eState: {focus: true}});
           }
           return true;
         }
@@ -273,10 +272,10 @@ export default class HoverEditorPlugin extends Plugin {
     });
   }
 
-  spawnPopover(initiatingEl?: HTMLElement) {
+  spawnPopover(initiatingEl?: HTMLElement, onShowCallback?: () => any) {
     let parent = this.app.workspace.activeLeaf as unknown as HoverEditorParent;
     if (!initiatingEl) initiatingEl = parent.containerEl;
-    let hoverPopover = new HoverEditor(parent, initiatingEl, this);
+    let hoverPopover = new HoverEditor(parent, initiatingEl, this, undefined, onShowCallback);
 
     // @ts-ignore
     let split = new WorkspaceSplit(this.app.workspace, "horizontal");

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -19,7 +19,7 @@ export class HoverEditor extends HoverPopover {
   lockedOut: boolean;
   abortController: AbortController;
 
-  constructor(parent: HoverParent, targetEl: HTMLElement, plugin: HoverEditorPlugin, waitTime?: number) {
+  constructor(parent: HoverParent, targetEl: HTMLElement, plugin: HoverEditorPlugin, waitTime?: number, public onShowCallback?: () => any) {
     super(parent, targetEl, waitTime);
     this.plugin = plugin;
     this.createResizeHandles();
@@ -49,6 +49,7 @@ export class HoverEditor extends HoverPopover {
       this.parent.hoverPopover = this;
     }
     this.registerInteract();
+    this.onShowCallback?.();
   }
 
   onHide() {

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -50,6 +50,7 @@ export class HoverEditor extends HoverPopover {
     }
     this.registerInteract();
     this.onShowCallback?.();
+    this.onShowCallback = undefined; // only call it once
   }
 
   onHide() {

--- a/src/types/obsidian.d.ts
+++ b/src/types/obsidian.d.ts
@@ -79,8 +79,9 @@ declare module "obsidian" {
     scroll?: number;
   }
   interface OpenViewState {
-    eState: EphemeralState;
-    state: { mode: string };
+    eState?: EphemeralState;
+    state?: { mode: string };
+    active?: boolean;
   }
   interface HoverPopover {
     targetEl: HTMLElement;


### PR DESCRIPTION
Ensure popovers created by commands are always active and focused, even if they are empty.  (Also creates missing files when following the link at the cursor, just like the built-in follow-link command.)