### PR TITLE
Basic support for splits in hover popovers

### DIFF
--- a/src/leaf.ts
+++ b/src/leaf.ts
@@ -5,9 +5,7 @@ import {
   HoverEditorParent,
   OpenViewState,
   parseLinktext,
-  requireApiVersion,
   resolveSubpath,
-  setIcon,
   TFile,
   WorkspaceLeaf,
 } from "obsidian";
@@ -21,8 +19,6 @@ export class HoverLeaf extends WorkspaceLeaf {
   id: string;
   plugin: HoverEditorPlugin;
   hoverParent: HoverEditorParent;
-  pinEl: HTMLElement;
-  isPinned: boolean;
   detaching: boolean;
   opening: boolean;
 
@@ -32,7 +28,6 @@ export class HoverLeaf extends WorkspaceLeaf {
     this.detaching = false;
     this.plugin = plugin;
     this.hoverParent = parent;
-    this.addPinButton();
   }
 
   getRoot() {
@@ -44,28 +39,6 @@ export class HoverLeaf extends WorkspaceLeaf {
     let link = parseLinktext(linkText);
     let tFile = link ? this.app.metadataCache.getFirstLinkpathDest(link.path, sourcePath) : undefined;
     return tFile;
-  }
-
-  addPinButton() {
-    let pinEl = (this.pinEl = createDiv("popover-header-icon mod-pin-popover"));
-    pinEl.onclick = () => {
-      this.togglePin();
-    };
-    if (requireApiVersion && requireApiVersion("0.13.27")) {
-      setIcon(pinEl, "lucide-pin", 17);
-    } else {
-      setIcon(pinEl, "pin", 17);
-    }
-    return pinEl;
-  }
-
-  togglePin(value?: boolean) {
-    this.popover?.abortController?.abort();
-    if (value === undefined) {
-      value = !this.isPinned;
-    }
-    this.pinEl.toggleClass("is-active", value);
-    this.isPinned = value;
   }
 
   toggleMinimized(value?: boolean) {
@@ -125,7 +98,7 @@ export class HoverLeaf extends WorkspaceLeaf {
     } finally {
       this.opening = false;
     }
-    this.view.iconEl.replaceWith(this.pinEl);
+    if (this.popover) this.view.iconEl.replaceWith(this.popover.pinEl);
     if (openState.state?.mode === "source" || openState.eState) {
       setTimeout(() => {
         if (this.detaching) return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -162,7 +162,7 @@ export default class HoverEditorPlugin extends Plugin {
               .setTitle("Open in new popover")
               .onClick(() => {
                 let popover = this.spawnPopover();
-                popover.leaf.togglePin(true);
+                popover.togglePin(true);
                 if (!leaf) {
                   popover.leaf.openFile(file);
                 }
@@ -261,7 +261,7 @@ export default class HoverEditorPlugin extends Plugin {
       callback: () => {
         // Focus the leaf after it's shown
         let popover = this.spawnPopover(undefined, () => this.app.workspace.setActiveLeaf(popover.leaf, false, true));
-        popover.leaf.togglePin(true);
+        popover.togglePin(true);
       },
     });
     this.addCommand({
@@ -274,7 +274,7 @@ export default class HoverEditorPlugin extends Plugin {
             let token = activeView.editor.getClickableTokenAt(activeView.editor.getCursor());
             if (token?.type === "internal-link") {
               let popover = this.spawnPopover();
-              popover.leaf.togglePin(true);
+              popover.togglePin(true);
               popover.leaf.openLinkText(token.text, activeView.file.path, {active: true, eState: {focus: true}});
             }
           }
@@ -291,7 +291,7 @@ export default class HoverEditorPlugin extends Plugin {
         if (!!activeView) {
           if (!checking) {
             let popover = this.spawnPopover();
-            popover.leaf.togglePin(true);
+            popover.togglePin(true);
             popover.leaf.openFile(activeView.file, { active: true, eState: { focus: true } });
           }
           return true;

--- a/src/onLinkHover.ts
+++ b/src/onLinkHover.ts
@@ -66,7 +66,7 @@ export function onLinkHover(
         createEl.addEventListener(
           "click",
           async function () {
-            leaf.togglePin(true);
+            hoverPopover.togglePin(true);
             await leaf.openLinkText(linkText, path);
             await leaf.openLink(linkText, path);
           },

--- a/src/onLinkHover.ts
+++ b/src/onLinkHover.ts
@@ -1,5 +1,5 @@
-import { HoverEditorParent, PopoverState, WorkspaceSplit } from "obsidian";
-import { HoverLeaf } from "./leaf";
+import { PopoverState, WorkspaceSplit } from "obsidian";
+import { HoverEditorParent, HoverLeaf } from "./leaf";
 import { HoverEditor } from "./popover";
 import HoverEditorPlugin from "./main";
 
@@ -47,12 +47,7 @@ export function onLinkHover(
         return;
       }
 
-      //@ts-ignore the official API has no contructor for WorkspaceSplit
-      let split = new WorkspaceSplit(plugin.app.workspace, "horizontal");
-
-      let leaf = new HoverLeaf(this.app, plugin, parent);
-
-      hoverPopover.attachLeaf(leaf, split);
+      let leaf = hoverPopover.attachLeaf(parent);
 
       let result = await leaf.openLink(linkText, path, oldState);
 

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -4,6 +4,8 @@ import { HoverParent, HoverPopover, WorkspaceSplit } from "obsidian";
 import { HoverLeaf } from "./leaf";
 import HoverEditorPlugin from "./main";
 
+const popovers = new WeakMap<HTMLElement, HoverEditor>();
+
 export class HoverEditor extends HoverPopover {
   explicitClose: boolean;
   onTarget: boolean;
@@ -19,9 +21,14 @@ export class HoverEditor extends HoverPopover {
   lockedOut: boolean;
   abortController: AbortController;
 
+  static activePopovers() {
+    return document.body.findAll(".hover-popover").map(el => popovers.get(el)).filter(he => he);
+  }
+
   constructor(parent: HoverParent, targetEl: HTMLElement, plugin: HoverEditorPlugin, waitTime?: number, public onShowCallback?: () => any) {
     super(parent, targetEl, waitTime);
     this.plugin = plugin;
+    popovers.set(this.hoverEl, this);
     this.createResizeHandles();
   }
 

--- a/src/types/obsidian.d.ts
+++ b/src/types/obsidian.d.ts
@@ -33,9 +33,12 @@ declare module "obsidian" {
   interface WorkspaceLeaf {
     openLinkText(linkText: string, path: string, state?: any): Promise<void>;
     working: boolean;
+    parentSplit: WorkspaceParent;
+    activeTime: number;
   }
   interface Workspace {
     recordHistory(leaf: WorkspaceLeaf, pushHistory: boolean): void;
+    iterateLeaves(callback: (item: WorkspaceItem) => any, item: WorkspaceItem): void;
   }
   interface Editor {
     getClickableTokenAt(pos: EditorPosition): {

--- a/src/types/obsidian.d.ts
+++ b/src/types/obsidian.d.ts
@@ -1,6 +1,5 @@
 import type { EditorView } from "@codemirror/view";
-import { Plugin, OpenViewState } from "obsidian";
-import { HoverEditor } from "../popover";
+import { Plugin } from "obsidian";
 
 declare module "obsidian" {
   interface App {
@@ -100,12 +99,5 @@ declare module "obsidian" {
   interface Pos {
     x: number;
     y: number;
-  }
-
-  interface HoverEditorParent {
-    hoverPopover: HoverEditor | null;
-    containerEl?: HTMLElement;
-    view?: View;
-    dom?: HTMLElement;
   }
 }


### PR DESCRIPTION
This change makes it so that:

- Popovers are tracked with a weakmap so the Array hack isn't needed
- All leaves are closed when a popover is closed (or the plugin unloaded)
- Toggling of pin and minimize states is handled by the popover instead of a leaf
- Closing a leaf doesn't close the popover unless it's the last leaf
- Closing an active leaf activates the most-recently active leaf in the popover, or in the workspace root if the popover is closing

I've broken it into mutliple commits so you can review it piecemeal instead of in one giant gulp.

Here's what's *not* done, yet:

- The pin icon is a bit wonky with multiple files; it moves to the most-recently opened leaf instead of staying in one spot.  I think it might work better if it were placed in the popover body at an absolute position to just overlay the first leaf's header rather than actually being placed in the leaf's header.  Some experimentation is required, but for now the behavior for a popover with just one leaf is the same as before this PR.
- I haven't changed the menu filtering, though in my tests the split operations work fine.  Operations that link or use links between panes don't work properly, although they show the link icon in the panes and do the initial file loading just fine.  Popover leaves are also not seen as a valid target for linking.  These things need some investigation.
- Minimizing with horizontal splits still produces ugly results

The intention at this point is this should be mergeable without affecting any single-pane functionality, just making improvements to the usability of multi-panes without making them a fully supported feature yet.