### PR TITLE
Always display pin on first leaf

### DIFF
--- a/src/leaf.ts
+++ b/src/leaf.ts
@@ -87,7 +87,7 @@ export class HoverLeaf extends WorkspaceLeaf {
     } finally {
       this.opening = false;
     }
-    if (this.popover) this.view.iconEl.replaceWith(this.popover.pinEl);
+    if (this.popover) this.popover.placePin();
     if (openState.state?.mode === "source" || openState.eState) {
       setTimeout(() => {
         if (this.detaching) return;

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -52,6 +52,18 @@ export class HoverEditor extends HoverPopover {
     this.isPinned = value;
   }
 
+  placePin() {
+    const firstHeader = this.hoverEl.find(".view-header"), pinHeader = this.hoverEl.find(".popover-header-icon");
+    if (firstHeader && firstHeader !== pinHeader) {
+      firstHeader.prepend(this.pinEl);
+    }
+  }
+
+  onload() {
+    super.onload();
+    this.registerEvent(this.plugin.app.workspace.on("layout-change", this.placePin, this));
+  }
+
   toggleMinimized(value?: boolean) {
     let hoverEl = this.hoverEl;
 
@@ -77,6 +89,7 @@ export class HoverEditor extends HoverPopover {
     this.togglePin(this.plugin.settings.autoPin === "always" ? true : false);
     this.rootSplit.insertChild(0, leaf);
     this.hoverEl.prepend(this.rootSplit.containerEl);
+    this.placePin();
     return leaf;
   }
 

--- a/styles.css
+++ b/styles.css
@@ -91,22 +91,10 @@ body.is-dragging-popover .tooltip {
 }
 
 .popover.hover-popover .view-header-icon {
-  visibility: hidden;
+  display: none;
 }
 
 .popover.hover-popover .workspace-split > .workspace-leaf:last-child > .workspace-leaf-resize-handle {
   display: none;
 }
 
-.popover.hover-popover .empty-state-title,
-.popover.hover-popover .workspace-leaf-content[data-type="empty"] .view-header {
-  display: unset;
-}
-
-.popover.hover-popover .workspace-leaf-content[data-type="empty"] .view-header-icon {
-  display: none;
-}
-
-.popover.hover-popover .empty-state-title {
-  display: none;
-}


### PR DESCRIPTION
This fixes the funkiness with pin positioning in popovers with splits (as described in #27).  It also uniformly hides the view icons so as to disable dragging them, and to free up space in the header.  (It turns out if they're visible/draggable, you can actually drag them out and drop them into other places in the workspace!  But I'm not sure we want to enable that without a review of how moving a HoverLeaf to a regular workspace split might go badly.)