### PR TITLE
Register graph hook early (Fix #37)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,14 @@ export default class HoverEditorPlugin extends Plugin {
   settingsTab: SettingTab;
 
   async onload() {
+    this.registerActivePopoverHandler();
+    this.registerViewportResizeHandler();
+    this.registerContextMenuHandler();
+    this.registerCommands();
+    this.patchUnresolvedGraphNodeHover();
+    this.patchWorkspace();
+    this.patchWorkspaceLeaf();
+
     await this.loadSettings();
     this.registerSettingsTab();
 
@@ -31,13 +39,6 @@ export default class HoverEditorPlugin extends Plugin {
           30000
         );
       }
-      this.registerActivePopoverHandler();
-      this.registerViewportResizeHandler();
-      this.registerContextMenuHandler();
-      this.registerCommands();
-      this.patchUnresolvedGraphNodeHover();
-      this.patchWorkspace();
-      this.patchWorkspaceLeaf();
       this.patchSlidingPanes();
       this.patchLinkHover();
     });


### PR DESCRIPTION
(Most of the registrations don't need to wait for the workspace to be loaded, so I moved all of those up, not just the graph hook.)