### PR TITLE
Minimize file-open suppression

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -80,14 +80,6 @@ export default class HoverEditorPlugin extends Plugin {
           return old.call(this, leaf, pushHistory, ...args);
         };
       },
-      trigger(old: any) {
-        return function (event: string, ...args: any[]) {
-          if (event === "file-open" && isHoverLeaf(this.activeLeaf)) {
-            return;
-          }
-          return old.call(this, event, ...args);
-        };
-      },
       iterateAllLeaves(old) {
         return function(cb) {
           this.iterateRootLeaves(cb);


### PR DESCRIPTION
This update allows hovered editors to be included in normal recent-file tracking, provided that you either manually focus the popup (not autofocused) or opened another popup from it and then returned focus to it.  If a popup is autofocused it will not be treated as the file being opened for purposes of the quick switcher or other plugins monitoring file-open unless you switch focus away and back again.