### PR TITLE
Add a closeDelay setting

### DIFF
--- a/src/onLinkHover.ts
+++ b/src/onLinkHover.ts
@@ -22,7 +22,7 @@ export function onLinkHover(
       hoverPopover.targetEl === targetEl
     )
   ) {
-    hoverPopover = parent.hoverPopover = new HoverEditor(parent, targetEl, plugin, plugin.settings.triggerDelay + 200);
+    hoverPopover = parent.hoverPopover = new HoverEditor(parent, targetEl, plugin, plugin.settings.triggerDelay);
 
     const controller = (hoverPopover.abortController = new AbortController());
 
@@ -56,6 +56,6 @@ export function onLinkHover(
       // leaf.leafMemLeak = new Uint8Array(1024 * 1024 * 10);
       // // @ts-ignore
       // leaf.view.leafViewMemLeak = new Uint8Array(1024 * 1024 * 10);
-    }, plugin.settings.triggerDelay);
+    }, 100);
   }
 }

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -1,7 +1,7 @@
 import { Interactable, InteractEvent, ResizeEvent } from "@interactjs/types";
 import interact from "interactjs";
 import { around } from "monkey-around";
-import { EphemeralState, HoverParent, HoverPopover, Menu, OpenViewState, parseLinktext, requireApiVersion, resolveSubpath, setIcon, TFile, View, Workspace, WorkspaceLeaf, WorkspaceSplit } from "obsidian";
+import { EphemeralState, HoverPopover, Menu, OpenViewState, parseLinktext, requireApiVersion, resolveSubpath, setIcon, TFile, View, Workspace, WorkspaceLeaf, WorkspaceSplit } from "obsidian";
 import HoverEditorPlugin from "./main";
 
 const SNAP_DISTANCE = 10;
@@ -21,14 +21,12 @@ export interface HoverEditorParent {
 }
 
 export class HoverEditor extends HoverPopover {
-  explicitClose: boolean;
   onTarget: boolean;
   onHover: boolean;
   isPinned: boolean = this.plugin.settings.autoPin === "always" ? true : false;
   isDragging: boolean;
   isResizing: boolean;
   activeMenu: Menu;
-  parent: HoverEditorParent;
   interact: Interactable;
   lockedOut: boolean;
   abortController: AbortController;
@@ -39,6 +37,7 @@ export class HoverEditor extends HoverPopover {
     WorkspaceSplit as new(ws: Workspace, dir: string) => WorkspaceSplit
   )(this.plugin.app.workspace, "vertical");
   pinEl: HTMLElement;
+  oldPopover = this.parent.hoverPopover;
 
   static activePopovers() {
     return document.body.findAll(".hover-popover").map(el => popovers.get(el)).filter(he => he);
@@ -56,7 +55,7 @@ export class HoverEditor extends HoverPopover {
     return false;
   }
 
-  constructor(parent: HoverParent, targetEl: HTMLElement, public plugin: HoverEditorPlugin, waitTime?: number, public onShowCallback?: () => any) {
+  constructor(parent: HoverEditorParent, targetEl: HTMLElement, public plugin: HoverEditorPlugin, waitTime?: number, public onShowCallback?: () => any) {
     super(parent, targetEl, waitTime);
     popovers.set(this.hoverEl, this);
     const pinEl = this.pinEl = createDiv("popover-header-icon mod-pin-popover");
@@ -144,6 +143,11 @@ export class HoverEditor extends HoverPopover {
   }
 
   onShow() {
+    // Once we've been open for closeDelay, use the closeDelay as a hiding timeout
+    const {closeDelay} = this.plugin.settings;
+    setTimeout(() => this.waitTime = closeDelay, closeDelay);
+
+    this.oldPopover?.hide();
     this.hoverEl.toggleClass("is-new", true);
     document.body.addEventListener(
       "click",

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -148,6 +148,8 @@ export class HoverEditor extends HoverPopover {
     setTimeout(() => this.waitTime = closeDelay, closeDelay);
 
     this.oldPopover?.hide();
+    this.oldPopover = null;
+
     this.hoverEl.toggleClass("is-new", true);
     document.body.addEventListener(
       "click",
@@ -165,6 +167,7 @@ export class HoverEditor extends HoverPopover {
   }
 
   onHide() {
+    this.oldPopover = null;
     if (this.parent?.hoverPopover === this) {
       this.parent.hoverPopover = null;
     }

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -5,6 +5,7 @@ export interface HoverEditorSettings {
   defaultMode: string;
   autoPin: string;
   triggerDelay: number;
+  closeDelay: number;
   autoFocus: boolean;
   rollDown: boolean;
   snapToEdges: boolean;
@@ -13,7 +14,8 @@ export interface HoverEditorSettings {
 export const DEFAULT_SETTINGS: HoverEditorSettings = {
   defaultMode: "preview",
   autoPin: "onMove",
-  triggerDelay: 200,
+  triggerDelay: 300,
+  closeDelay: 600,
   autoFocus: true,
   rollDown: false,
   snapToEdges: false,
@@ -99,13 +101,26 @@ export class SettingTab extends PluginSettingTab {
 
     new Setting(containerEl)
       .setName("Hover Trigger Delay (ms)")
-      .setDesc("How long to wait before triggering a Hover Editor when hovering over a link")
+      .setDesc("How long to wait before showing a Hover Editor when hovering over a link")
       .addText(textfield => {
-        textfield.setPlaceholder(String(200));
+        textfield.setPlaceholder(String(300));
         textfield.inputEl.type = "number";
         textfield.setValue(String(this.plugin.settings.triggerDelay));
         textfield.onChange(async value => {
           this.plugin.settings.triggerDelay = Number(value);
+          this.plugin.saveSettings();
+        });
+      });
+
+      new Setting(containerEl)
+      .setName("Hover Close Delay (ms)")
+      .setDesc("How long to wait before closing a Hover Editor once the mouse leaves")
+      .addText(textfield => {
+        textfield.setPlaceholder(String(600));
+        textfield.inputEl.type = "number";
+        textfield.setValue(String(this.plugin.settings.closeDelay));
+        textfield.onChange(async value => {
+          this.plugin.settings.closeDelay = Number(value);
           this.plugin.saveSettings();
         });
       });

--- a/src/types/obsidian.d.ts
+++ b/src/types/obsidian.d.ts
@@ -1,5 +1,6 @@
 import type { EditorView } from "@codemirror/view";
 import { Plugin } from "obsidian";
+import { HoverEditorParent } from "src/popover";
 
 declare module "obsidian" {
   interface App {
@@ -99,12 +100,15 @@ declare module "obsidian" {
     active?: boolean;
   }
   interface HoverPopover {
+    parent: HoverEditorParent
     targetEl: HTMLElement;
     hoverEl: HTMLElement;
     position(pos?: Pos): void;
     hide(): void;
+    show(): void;
     shouldShowSelf(): boolean;
     timer: number;
+    waitTime: number;
   }
   interface Pos {
     x: number;


### PR DESCRIPTION
For improved accessibility, allow setting a different delay for closing popovers than opening them. This makes it easier for people with co-ordination challenges to resize an unpinned popover without accidentally closing it.  Once a popover has been open for the close delay, it will persist for the close delay before closing after the cursor moves, unless a new popup is triggered sooner.

Also, adjusted the defaults and timing algorithms to more closely match those of Obsidian core, which waits 100ms after a hover is triggered to begin loading the file, and shows the popover after 300ms (200ms after the file open begins), and to ensure that even with a long close delay, popups are not indefinitely cascaded for the same parent.