### PR TITLE
Don't leak a graph worker at startup

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,12 @@
 import { around } from "monkey-around";
 import {
+  App,
   debounce,
   MarkdownView,
   Menu,
   Notice,
   Plugin,
   PopoverState,
-  SplitDirection,
   TAbstractFile,
   TFile,
   Workspace,
@@ -211,10 +211,11 @@ export default class HoverEditorPlugin extends Plugin {
   }
 
   patchUnresolvedGraphNodeHover() {
-    // @ts-ignore
-    let leaf = new WorkspaceLeaf(this.app);
-    // @ts-ignore
-    let GraphEngine = this.app.internalPlugins.plugins.graph.views.localgraph(leaf).engine.constructor;
+    let leaf = new (WorkspaceLeaf as new (app: App) => WorkspaceLeaf)(this.app);
+    let view: any = (this.app.internalPlugins.plugins.graph as any).views.localgraph(leaf)
+    let GraphEngine = view.engine.constructor;
+    leaf.detach(); // close the view
+    view.renderer?.worker?.terminate(); // ensure the worker is terminated
     let uninstall = around(GraphEngine.prototype, {
       // @ts-ignore
       onNodeHover(old: any) {


### PR DESCRIPTION
The previous code created a view but never closed it, causing the Graph Worker to leak, forever consuming memory and CPU each time the plugin restarted.  (I was wondering why doing dev work on HE was exploding my Obsidian process size!)  This fix also contains a workaround for a core bug whereby local graph views don't terminate their worker, either.  (Slated to be fixed in 0.14.3, but the workaround should still be compatible.)