### PR TITLE
maint: decouple and replace native Obsidian HoverPopover logic

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -411,7 +411,7 @@ export default class HoverEditorPlugin extends Plugin {
   }
 
   onunload(): void {
-    HoverEditor.activePopovers().forEach(popover => popover.explicitHide());
+    HoverEditor.activePopovers().forEach(popover => popover.hide());
   }
 
   async loadSettings() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,6 @@ export default class HoverEditorPlugin extends Plugin {
     this.patchQuickSwitcher();
     this.patchWorkspaceLeaf();
     this.patchItemView();
-    this.patchMenu();
 
     await this.loadSettings();
     this.registerSettingsTab();
@@ -130,28 +129,6 @@ export default class HoverEditorPlugin extends Plugin {
             return false;
           });
           return result;
-        };
-      },
-    });
-    this.register(uninstaller);
-  }
-
-  patchMenu() {
-    const plugin = this;
-    const uninstaller = around(Menu.prototype, {
-      onload(old) {
-        return function (...args: unknown[]) {
-          plugin.activePopovers.forEach(popover => {
-            if (!popover.isPinned && !popover.activeMenu) {
-              popover.activeMenu = this;
-              this.register(() => {
-                setTimeout(() => {
-                  if (popover.activeMenu === this) popover.activeMenu = undefined;
-                }, 10);
-              });
-            }
-          });
-          return old.call(this, ...args);
         };
       },
     });
@@ -288,14 +265,6 @@ export default class HoverEditorPlugin extends Plugin {
     this.registerEvent(
       this.app.workspace.on("file-menu", (menu: Menu, file: TAbstractFile, source: string, leaf?: WorkspaceLeaf) => {
         const popover = leaf ? HoverEditor.forLeaf(leaf) : undefined;
-        if (source === "pane-more-options" && popover) {
-          popover.activeMenu = menu;
-          menu.hideCallback = function () {
-            setTimeout(() => {
-              if (popover?.activeMenu === menu) popover.activeMenu = undefined;
-            }, 1000);
-          };
-        }
         if (file instanceof TFile && !popover && !leaf) {
           menu.addItem(item => {
             item

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ import {
 } from "obsidian";
 
 import { onLinkHover } from "./onLinkHover";
-import { HoverEditorParent, HoverEditor, isHoverLeaf } from "./popover";
+import { HoverEditorParent, HoverEditor, isHoverLeaf, setMouseCoords } from "./popover";
 import { DEFAULT_SETTINGS, HoverEditorSettings, SettingTab } from "./settings/settings";
 
 export default class HoverEditorPlugin extends Plugin {
@@ -235,6 +235,12 @@ export default class HoverEditorPlugin extends Plugin {
     const pagePreviewPlugin = this.app.internalPlugins.plugins["page-preview"];
     if (!pagePreviewPlugin.enabled) return;
     const uninstaller = around(pagePreviewPlugin.instance.constructor.prototype, {
+      onHoverLink(old: Function) {
+        return function (options: { event: MouseEvent }, ...args: unknown[]) {
+          if (options && options.event instanceof MouseEvent) setMouseCoords(options.event);
+          return old.call(this, options, ...args);
+        };
+      },
       onLinkHover(old: Function) {
         return function (
           parent: HoverEditorParent,

--- a/src/onLinkHover.ts
+++ b/src/onLinkHover.ts
@@ -18,7 +18,8 @@ export function onLinkHover(
     prevPopover &&
     prevPopover.state !== PopoverState.Hidden &&
     prevPopover.targetEl !== null &&
-    prevPopover.targetEl === targetEl;
+    targetEl &&
+    prevPopover.adopt(targetEl);
 
   if (!parentHasExistingPopover) {
     const editor = new HoverEditor(parent, targetEl, plugin, plugin.settings.triggerDelay);

--- a/src/onLinkHover.ts
+++ b/src/onLinkHover.ts
@@ -32,7 +32,7 @@ export function onLinkHover(
 
     const onMouseDown = function (event: MouseEvent) {
       if (!editor) return;
-      if (!editor.activeMenu && event.target instanceof HTMLElement && !event.target.closest(".hover-editor")) {
+      if (!editor.activeMenu && event.target instanceof HTMLElement && !event.target.closest(".hover-editor, .menu")) {
         editor.state = PopoverState.Hidden;
         editor.explicitHide();
         editor.lockedOut = true;

--- a/src/onLinkHover.ts
+++ b/src/onLinkHover.ts
@@ -32,7 +32,7 @@ export function onLinkHover(
 
     const onMouseDown = function (event: MouseEvent) {
       if (!editor) return;
-      if (!editor.activeMenu && event.target instanceof HTMLElement && !event.target.closest(".hover-editor, .menu")) {
+      if (event.target instanceof HTMLElement && !event.target.closest(".hover-editor, .menu")) {
         editor.state = PopoverState.Hidden;
         editor.hide();
         editor.lockedOut = true;

--- a/src/onLinkHover.ts
+++ b/src/onLinkHover.ts
@@ -34,7 +34,7 @@ export function onLinkHover(
       if (!editor) return;
       if (!editor.activeMenu && event.target instanceof HTMLElement && !event.target.closest(".hover-editor, .menu")) {
         editor.state = PopoverState.Hidden;
-        editor.explicitHide();
+        editor.hide();
         editor.lockedOut = true;
         setTimeout(unlock, 1000);
       }

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -40,10 +40,16 @@ export interface HoverEditorParent {
   dom?: HTMLElement;
 }
 type ConstructableWorkspaceSplit = new (ws: Workspace, dir: string) => WorkspaceSplit;
+
+// eslint-disable-next-line prefer-const
+let mouseCoords: Pos | null = null;
+
 export class HoverEditor extends HoverPopover {
   onTarget: boolean;
 
   onHover: boolean;
+
+  shownPos: Pos | null;
 
   isPinned: boolean = this.plugin.settings.autoPin === "always" ? true : false;
 
@@ -83,6 +89,10 @@ export class HoverEditor extends HoverPopover {
 
   dragElementRect: { top: number; left: number; bottom: number; right: number };
 
+  onMouseIn: (event: MouseEvent) => void;
+
+  onMouseOut: (event: MouseEvent) => void;
+
   xspeed: number;
 
   yspeed: number;
@@ -118,7 +128,63 @@ export class HoverEditor extends HoverPopover {
     waitTime?: number,
     public onShowCallback?: () => unknown,
   ) {
+    //
     super(parent, targetEl, waitTime);
+    //
+    // unset native handlers which were set during the super call
+    //
+    if (targetEl) {
+      targetEl.removeEventListener("mouseover", this.onMouseIn);
+      targetEl.removeEventListener("mouseout", this.onMouseOut);
+    }
+    window.clearTimeout(this.timer);
+    // end
+    if (waitTime === undefined) {
+      waitTime = 300;
+    }
+    this.onTarget = true;
+    this.onHover = false;
+    this.shownPos = null;
+    this.parent = parent;
+    this.targetEl = targetEl;
+    this.waitTime = waitTime;
+    this.state = PopoverState.Showing;
+    const hoverEl = (this.hoverEl = createDiv("popover hover-popover"));
+    this.onMouseIn = this._onMouseIn.bind(this);
+    this.onMouseOut = this._onMouseOut.bind(this);
+
+    if (targetEl) {
+      targetEl.addEventListener("mouseover", this.onMouseIn);
+      targetEl.addEventListener("mouseout", this.onMouseOut);
+    }
+
+    hoverEl.addEventListener("mouseover", event => {
+      if (mouseIsOffTarget(event, hoverEl)) {
+        this.onHover = true;
+        this.transition();
+      }
+    });
+    hoverEl.addEventListener("mouseout", event => {
+      if (mouseIsOffTarget(event, hoverEl)) {
+        this.onHover = false;
+        this.transition();
+      }
+    });
+    this.timer = window.setTimeout(this.show.bind(this), waitTime);
+    document.addEventListener("mousemove", setMouseCoords);
+
+    // we can't stop popovers from getting added to the internal initializingHoverPopovers array
+    // but it's harmless since the entry will be removed when we call super.hide()
+    //
+    // initializingHoverPopovers.push(this);
+
+    // we can't stop the popoverChecker from running
+    // but it will clear itself in 500ms when it can't find any active popovers
+    // we prevent show() from adding the popover to the internal activeHoverPopovers array so it's always empty
+    //
+    // initializePopoverChecker();
+
+    // custom logic begin
     popovers.set(this.hoverEl, this);
     this.hoverEl.addClass("hover-editor");
     this.containerEl = this.hoverEl.createDiv("popover-content");
@@ -207,10 +273,6 @@ export class HoverEditor extends HoverPopover {
       this.toggleConstrainAspectRatio(false);
     }
     this.hoverEl.setAttribute("data-leaf-count", leafCount.toString());
-  }
-
-  onload() {
-    super.onload();
   }
 
   get headerHeight() {
@@ -415,20 +477,100 @@ export class HoverEditor extends HoverPopover {
   }
 
   transition() {
-    super.transition();
-    if (!this.shouldShow() && this.state === PopoverState.Showing) {
-      this.explicitHide();
+    if (this.shouldShow()) {
+      if (this.state === PopoverState.Hiding) {
+        this.state = PopoverState.Shown;
+        clearTimeout(this.timer);
+      }
+    } else {
+      if (this.state === PopoverState.Showing) {
+        this.explicitHide();
+      } else {
+        if (this.state === PopoverState.Shown) {
+          this.state = PopoverState.Hiding;
+          this.timer = window.setTimeout(() => {
+            if (this.shouldShow()) {
+              this.transition();
+            } else {
+              this.hide();
+            }
+          }, this.waitTime);
+        }
+      }
     }
   }
 
-  position(pos?: Pos): void {
+  detect(el: HTMLElement) {
+    // TODO: may not be needed? the mouseover/out handers handle most detection use cases
+    const { targetEl, hoverEl } = this;
+
+    if (targetEl) {
+      this.onTarget = el === targetEl || targetEl.contains(el);
+    }
+
+    this.onHover = el === hoverEl || hoverEl.contains(el);
+  }
+
+  _onMouseIn(event: MouseEvent) {
+    if (!(this.targetEl && !mouseIsOffTarget(event, this.targetEl))) {
+      this.onTarget = true;
+      this.transition();
+    }
+  }
+
+  _onMouseOut(event: MouseEvent) {
+    if (!(this.targetEl && !mouseIsOffTarget(event, this.targetEl))) {
+      this.onTarget = false;
+      this.transition();
+    }
+  }
+
+  position(pos?: Pos | null): void {
     // without this adjustment, the x dimension keeps sliding over to the left as you progressively mouse over files
     // disabling this for now since messing with pos.x like this breaks the detect() logic
     // if (pos && pos.x !== undefined) {
     //   pos.x = pos.x + 20;
     // }
-    super.position(pos);
+
+    // native obsidian logic
+    if (pos === undefined) {
+      pos = this.shownPos;
+    }
+
+    let rect;
+
     if (pos) {
+      rect = {
+        top: pos.y - 10,
+        bottom: pos.y + 10,
+        left: pos.x,
+        right: pos.x,
+      };
+    } else if (this.targetEl) {
+      const relativePos = getRelativePos(this.targetEl, document.body);
+      rect = {
+        top: relativePos.top,
+        bottom: relativePos.top + this.targetEl.offsetHeight,
+        left: relativePos.left,
+        right: relativePos.left + this.targetEl.offsetWidth,
+      };
+    } else {
+      rect = {
+        top: 0,
+        bottom: 0,
+        left: 0,
+        right: 0,
+      };
+    }
+
+    document.body.appendChild(this.hoverEl);
+    positionEl(rect, this.hoverEl, {
+      gap: 10,
+    });
+
+    // custom hover editor logic
+    if (pos) {
+      // give positionEl a chance to adjust the position before we read the coords
       setTimeout(() => {
         const left = parseFloat(this.hoverEl.style.left);
         const top = parseFloat(this.hoverEl.style.top);
@@ -453,9 +595,31 @@ export class HoverEditor extends HoverPopover {
     this.hide();
   }
 
+  shouldShow() {
+    return this.shouldShowSelf() || this.shouldShowChild();
+  }
+
+  shouldShowChild(): boolean {
+    return HoverEditor.activePopovers().some(popover => {
+      if (popover !== this && popover.targetEl && this.hoverEl.contains(popover.targetEl)) {
+        return popover.shouldShow();
+      }
+      return false;
+    });
+  }
+
   shouldShowSelf() {
     // Don't let obsidian show() us if we've already started closing
-    return !this.detaching && (this.onTarget || this.onHover);
+    // return !this.detaching && (this.onTarget || this.onHover);
+    return (
+      !this.detaching &&
+      !!(
+        this.onTarget ||
+        this.onHover ||
+        document.querySelector("body>.modal-container") ||
+        document.querySelector("body>.menu")
+      )
+    );
   }
 
   calculateMinSize() {
@@ -679,7 +843,23 @@ export class HoverEditor extends HoverPopover {
   }
 
   show() {
-    super.show();
+    // native obsidian logic start
+    if (!this.targetEl || document.body.contains(this.targetEl)) {
+      this.state = PopoverState.Shown;
+      this.timer = 0;
+      this.shownPos = mouseCoords;
+      this.position(mouseCoords);
+      document.removeEventListener("mousemove", setMouseCoords);
+      this.onShow();
+      // initializingHoverPopovers.remove(this);
+      // activeHoverPopovers.push(this);
+      // initializePopoverChecker();
+      this.load();
+    } else {
+      this.hide();
+    }
+    // native obsidian logic end
+
     // if this is an image view, set the dimensions to the natural dimensions of the image
     // an interactjs reflow will be triggered to constrain the image to the viewport if it's
     // too large
@@ -733,6 +913,40 @@ export class HoverEditor extends HoverPopover {
         return super.hide();
       }
     }
+  }
+
+  _nativeHide() {
+    // for reference purposes only. do not call.
+    // this is what the base class does when we call super.hide()
+    const hoverEl = this.hoverEl;
+    const targetEl = this.targetEl;
+    this.state = PopoverState.Hidden;
+    // initializingHoverPopovers.remove(this);
+    // activeHoverPopovers.remove(this);
+    clearTimeout(this.timer);
+    hoverEl.detach();
+
+    if (targetEl) {
+      targetEl.removeEventListener("mouseover", this.onMouseIn);
+      targetEl.removeEventListener("mouseout", this.onMouseOut);
+    }
+
+    this.onTarget = false;
+    this.onHover = false;
+    // note: activeHoverPopovers does not get populated so this logic will not run
+    // this is responsible for closing any child popovers when a parent popover is closed
+    // activeHoverPopovers
+    //   .filter(popver => {
+    //     if (popver.targetEl) {
+    //       return this.hoverEl.contains(popver.targetEl);
+    //     }
+    //     return false;
+    //   })
+    //   .forEach(popover => {
+    //     return popover.hide();
+    //   });
+    this.onHide();
+    this.unload();
   }
 
   resolveLink(linkText: string, sourcePath: string): TFile | null {
@@ -897,4 +1111,138 @@ export class HoverEditor extends HoverPopover {
 
 export function isHoverLeaf(leaf: WorkspaceLeaf) {
   return !!HoverEditor.forLeaf(leaf);
+}
+
+/**
+ * It positions an element relative to a rectangle, taking into account the boundaries of the element's
+ * offset parent
+ * @param rect - The rectangle of the element you want to position the popup relative to.
+ * @param {HTMLElement} el - The element to position
+ * @param [options] - {
+ * @returns An object with the top, left, and vresult properties.
+ */
+export function positionEl(
+  rect: { top: number; bottom: number; left: number; right: number },
+  el: HTMLElement,
+  options?: { gap?: number; preference?: string; offsetParent?: HTMLElement; horizontalAlignment?: string },
+) {
+  options = options || {};
+  el.show();
+  const gap = options.gap || 0;
+  const verticalPref = options.preference || "bottom";
+  const parentEl = options.offsetParent || el.offsetParent || document.documentElement;
+  const horizontalAlignment = options.horizontalAlignment || "left";
+  const parentTop = parentEl.scrollTop + 10;
+  const parentBottom = parentEl.scrollTop + parentEl.clientHeight - 10;
+  const top = Math.min(rect.top, parentBottom);
+  const bottom = Math.max(rect.bottom, parentTop);
+  const elHeight = el.offsetHeight;
+  const fitsAbove = rect.top - parentTop >= elHeight + gap;
+  const fitsBelow = parentBottom - rect.bottom >= elHeight + gap;
+  let topResult = 0;
+  let vresult = ""; // vertical result
+
+  if (!fitsAbove || ("top" !== verticalPref && fitsBelow)) {
+    if (!fitsBelow || ("bottom" !== verticalPref && fitsAbove)) {
+      if (parentEl.clientHeight < elHeight + gap) {
+        topResult = parentTop;
+        vresult = "overlap";
+      } else {
+        if ("top" === verticalPref) {
+          topResult = parentTop + gap;
+          vresult = "overlap";
+        } else {
+          topResult = parentBottom - elHeight;
+          vresult = "overlap";
+        }
+      }
+    } else {
+      topResult = bottom + gap;
+      vresult = "bottom";
+    }
+  } else {
+    topResult = top - gap - elHeight;
+    vresult = "top";
+  }
+
+  const leftBoundary = parentEl.scrollLeft + 10;
+  const rightBoundary = parentEl.scrollLeft + parentEl.clientWidth - 10;
+  const elWidth = el.offsetWidth;
+  let leftResult = "left" === horizontalAlignment ? rect.left : rect.right - elWidth;
+
+  if (leftResult < leftBoundary) {
+    leftResult = leftBoundary;
+  } else {
+    if (leftResult > rightBoundary - elWidth) {
+      leftResult = rightBoundary - elWidth;
+    }
+  }
+
+  el.style.top = "".concat(topResult.toString(), "px");
+  el.style.left = "".concat(leftResult.toString(), "px");
+
+  return {
+    top: topResult,
+    left: leftResult,
+    vresult: vresult,
+  };
+}
+
+/**
+ * "Get the position of an element relative to a parent element."
+ *
+ * The function takes two arguments:
+ *
+ * el: The element whose position we want to get.
+ * parentEl: The parent element to which we want to get the relative position.
+ * The function returns an object with two properties:
+ *
+ * top: The top position of the element relative to the parent element.
+ * left: The left position of the element relative to the parent element.
+ *
+ * The function works by looping through the offsetParent chain of the element and subtracting the
+ * scrollTop and scrollLeft values of the parent elements
+ * @param {HTMLElement | null} el - The element you want to get the relative position of.
+ * @param {HTMLElement | null} parentEl - The parent element that you want to get the relative position
+ * of.
+ * @returns An object with two properties, top and left.
+ */
+function getRelativePos(el: HTMLElement | null, parentEl: HTMLElement | null) {
+  let top = 0,
+    left = 0;
+  for (let nextParentEl = parentEl ? parentEl.offsetParent : null; el && el !== parentEl && el !== nextParentEl; ) {
+    top += el.offsetTop;
+    left += el.offsetLeft;
+    const offsetParent = el.offsetParent as HTMLElement | null;
+
+    for (let parent = el.parentElement; parent && parent !== offsetParent; ) {
+      top -= parent.scrollTop;
+      left -= parent.scrollLeft;
+      parent = parent.parentElement;
+    }
+
+    if (offsetParent && offsetParent !== parentEl && offsetParent !== nextParentEl) {
+      top -= offsetParent.scrollTop;
+      left -= offsetParent.scrollLeft;
+    }
+
+    el = offsetParent;
+  }
+
+  return {
+    top,
+    left,
+  };
+}
+
+function setMouseCoords(event: MouseEvent) {
+  mouseCoords = {
+    x: event.clientX,
+    y: event.clientY,
+  };
+}
+
+function mouseIsOffTarget(event: MouseEvent, el: Element) {
+  const relatedTarget = event.relatedTarget;
+  return !(relatedTarget instanceof Node && el.contains(relatedTarget));
 }

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -605,7 +605,7 @@ export class HoverEditor extends nosuper(HoverPopover) {
       !!(
         this.onTarget ||
         this.onHover ||
-        this.isPinned ||
+        (this.state == PopoverState.Shown && this.isPinned) ||
         document.querySelector(`body>.modal-container, body > #he${this.id} ~ .menu`)
       )
     );

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -8,7 +8,6 @@ import {
   EphemeralState,
   HoverPopover,
   MarkdownEditView,
-  Menu,
   OpenViewState,
   parseLinktext,
   PopoverState,
@@ -65,8 +64,6 @@ export class HoverEditor extends nosuper(HoverPopover) {
   isDragging: boolean;
 
   isResizing: boolean;
-
-  activeMenu?: Menu;
 
   interact?: Interactable;
 
@@ -152,7 +149,7 @@ export class HoverEditor extends nosuper(HoverPopover) {
     this.targetEl = targetEl;
     this.waitTime = waitTime;
     this.state = PopoverState.Showing;
-    const hoverEl = (this.hoverEl = createDiv("popover hover-popover"));
+    const hoverEl = (this.hoverEl = createDiv({ cls: "popover hover-popover", attr: { id: "he" + this.id } }));
     this.onMouseIn = this._onMouseIn.bind(this);
     this.onMouseOut = this._onMouseOut.bind(this);
 
@@ -609,8 +606,7 @@ export class HoverEditor extends nosuper(HoverPopover) {
         this.onTarget ||
         this.onHover ||
         this.isPinned ||
-        this.activeMenu ||
-        document.querySelector("body>.modal-container")
+        document.querySelector(`body>.modal-container, body > #he${this.id} ~ .menu`)
       )
     );
   }
@@ -878,7 +874,7 @@ export class HoverEditor extends nosuper(HoverPopover) {
 
   hide() {
     console.log(
-      `hiding popver ${this.id}: isPinned = ${this.isPinned}, activeMenu = ${this.activeMenu}, onHover = ${this.onHover}, onTarget = ${this.onTarget}`,
+      `hiding popver ${this.id}: isPinned = ${this.isPinned}, onHover = ${this.onHover}, onTarget = ${this.onTarget}`,
     );
     this.onTarget = this.onHover = false;
     this.isPinned = false;
@@ -929,6 +925,8 @@ export class HoverEditor extends nosuper(HoverPopover) {
     hoverEl.detach();
 
     if (targetEl) {
+      const parent = targetEl.matchParent(".hover-popover");
+      if (parent) popovers.get(parent)?.transition();
       targetEl.removeEventListener("mouseover", this.onMouseIn);
       targetEl.removeEventListener("mouseout", this.onMouseOut);
     }

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -11,7 +11,7 @@ import {
   OpenViewState,
   parseLinktext,
   PopoverState,
-  Pos,
+  MousePos,
   requireApiVersion,
   resolveSubpath,
   setIcon,
@@ -42,7 +42,7 @@ export interface HoverEditorParent {
 type ConstructableWorkspaceSplit = new (ws: Workspace, dir: string) => WorkspaceSplit;
 
 // eslint-disable-next-line prefer-const
-let mouseCoords: Pos | null = null;
+let mouseCoords: MousePos | null = null;
 
 function nosuper<T>(base: new (...args: unknown[]) => T): new () => T {
   const derived = function () {
@@ -57,7 +57,7 @@ export class HoverEditor extends nosuper(HoverPopover) {
 
   onHover: boolean;
 
-  shownPos: Pos | null;
+  shownPos: MousePos | null;
 
   isPinned: boolean = this.plugin.settings.autoPin === "always" ? true : false;
 
@@ -172,17 +172,6 @@ export class HoverEditor extends nosuper(HoverPopover) {
     });
     this.timer = window.setTimeout(this.show.bind(this), waitTime);
     document.addEventListener("mousemove", setMouseCoords);
-
-    // we can't stop popovers from getting added to the internal initializingHoverPopovers array
-    // but it's harmless since the entry will be removed when we call super.hide()
-    //
-    // initializingHoverPopovers.push(this);
-
-    // we can't stop the popoverChecker from running
-    // but it will clear itself in 500ms when it can't find any active popovers
-    // we prevent show() from adding the popover to the internal activeHoverPopovers array so it's always empty
-    //
-    // initializePopoverChecker();
 
     // custom logic begin
     popovers.set(this.hoverEl, this);
@@ -529,7 +518,7 @@ export class HoverEditor extends nosuper(HoverPopover) {
     }
   }
 
-  position(pos?: Pos | null): void {
+  position(pos?: MousePos | null): void {
     // without this adjustment, the x dimension keeps sliding over to the left as you progressively mouse over files
     // disabling this for now since messing with pos.x like this breaks the detect() logic
     // if (pos && pos.x !== undefined) {

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -311,8 +311,12 @@ export class HoverEditor extends nosuper(HoverPopover) {
     this.titleEl.insertAdjacentElement("afterend", this.rootSplit.containerEl);
     const leaf = this.plugin.app.workspace.createLeafInParent(this.rootSplit, 0);
     this.updateLeaves();
-    this.registerEvent(this.plugin.app.workspace.on("layout-change", this.updateLeaves, this));
     return leaf;
+  }
+
+  onload(): void {
+    super.onload();
+    this.registerEvent(this.plugin.app.workspace.on("layout-change", this.updateLeaves, this));
   }
 
   leaves() {

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -1005,9 +1005,11 @@ export class HoverEditor extends nosuper(HoverPopover) {
       const createEl = leaf.view.actionListEl?.createEl("button", "empty-state-action");
       if (!createEl) return;
       createEl.textContent = `${linkText} is not yet created. Click to create.`;
-      setTimeout(() => {
-        createEl?.focus();
-      }, 200);
+      if (this.parentAllowsAutoFocus) {
+        setTimeout(() => {
+          createEl?.focus();
+        }, 200);
+      }
       createEl.addEventListener(
         "click",
         async () => {

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -850,7 +850,6 @@ export class HoverEditor extends nosuper(HoverPopover) {
     }
     // native obsidian logic end
 
-    console.log(`spawning popover: ${this.id}`);
     // if this is an image view, set the dimensions to the natural dimensions of the image
     // an interactjs reflow will be triggered to constrain the image to the viewport if it's
     // too large
@@ -874,13 +873,13 @@ export class HoverEditor extends nosuper(HoverPopover) {
   }
 
   hide() {
-    console.log(
-      `hiding popver ${this.id}: isPinned = ${this.isPinned}, onHover = ${this.onHover}, onTarget = ${this.onTarget}`,
-    );
     this.onTarget = this.onHover = false;
     this.isPinned = false;
     this.detaching = true;
     // Once we reach this point, we're committed to closing
+
+    // in case we didn't ever call show()
+    document.removeEventListener("mousemove", setMouseCoords);
 
     // A timer might be pending to call show() for the first time, make sure
     // it doesn't bring us back up after we close
@@ -1236,7 +1235,7 @@ function getRelativePos(el: HTMLElement | null, parentEl: HTMLElement | null) {
   };
 }
 
-function setMouseCoords(event: MouseEvent) {
+export function setMouseCoords(event: MouseEvent) {
   mouseCoords = {
     x: event.clientX,
     y: event.clientY,

--- a/src/types/obsidian.d.ts
+++ b/src/types/obsidian.d.ts
@@ -140,7 +140,7 @@ declare module "obsidian" {
     parent: HoverEditorParent | null;
     targetEl: HTMLElement;
     hoverEl: HTMLElement;
-    position(pos?: Pos): void;
+    position(pos?: MousePos): void;
     hide(): void;
     show(): void;
     shouldShowSelf(): boolean;
@@ -149,7 +149,7 @@ declare module "obsidian" {
     shouldShow(): boolean;
     transition(): void;
   }
-  interface Pos {
+  interface MousePos {
     x: number;
     y: number;
   }


### PR DESCRIPTION
The first draft to decouple ourselves from all native HoverPopover behaviors.

We still subclass HoverPopover but we remove all `super` calls (except for the constructor and `super.hide()`) by overriding all class methods with our own logic.

The native constructor sets multiple event handlers and timeouts that we first have to immediately remove and replace with our own versions. There were also multiple internal function calls which we had to replicate such as `positionEl`, `getRelativePos`, `setMouseCoords`, and `mouseIsOffTarget`.

This first draft should be mostly functional but now that we're decoupled, the next step is refactoring certain things, like `explicitHide()`, that may not be needed anymore.

More commits to come before this PR is merged...

cc: @pjeby 