### PR TITLE
Fix misc. edge cases (wrapped links, calendar handling, duplicated popups)

### DIFF
--- a/src/onLinkHover.ts
+++ b/src/onLinkHover.ts
@@ -14,6 +14,15 @@ export function onLinkHover(
 ) {
   const prevPopover = parent.hoverPopover;
   if (prevPopover?.lockedOut) return;
+
+  // Tweak the targetEl for calendar to point to the table cell instead of the actual day,
+  // so the link won't be broken when the day div is recreated by calendar refreshing
+  if (
+    targetEl &&
+    targetEl.matches('.workspace-leaf-content[data-type="calendar"] table.calendar td > div')
+  )
+    targetEl = targetEl.parentElement!;
+
   const parentHasExistingPopover =
     prevPopover &&
     prevPopover.state !== PopoverState.Hidden &&

--- a/src/onLinkHover.ts
+++ b/src/onLinkHover.ts
@@ -18,11 +18,15 @@ export function onLinkHover(
     prevPopover &&
     prevPopover.state !== PopoverState.Hidden &&
     prevPopover.targetEl !== null &&
+    prevPopover.originalLinkText === linkText &&
+    prevPopover.originalPath === path &&
     targetEl &&
     prevPopover.adopt(targetEl);
 
   if (!parentHasExistingPopover) {
     const editor = new HoverEditor(parent, targetEl, plugin, plugin.settings.triggerDelay);
+    editor.originalLinkText = linkText;
+    editor.originalPath = path;
     parent.hoverPopover = editor;
     const controller = (editor.abortController = new AbortController());
 

--- a/src/onLinkHover.ts
+++ b/src/onLinkHover.ts
@@ -3,6 +3,8 @@ import { EphemeralState, PopoverState } from "obsidian";
 import HoverEditorPlugin from "./main";
 import { HoverEditorParent, HoverEditor } from "./popover";
 
+const targetPops = new WeakMap<HTMLElement, HoverEditor>();
+
 export function onLinkHover(
   plugin: HoverEditorPlugin,
   parent: HoverEditorParent,
@@ -12,9 +14,6 @@ export function onLinkHover(
   oldState: EphemeralState,
   ...args: unknown[]
 ) {
-  const prevPopover = parent.hoverPopover;
-  if (prevPopover?.lockedOut) return;
-
   // Tweak the targetEl for calendar to point to the table cell instead of the actual day,
   // so the link won't be broken when the day div is recreated by calendar refreshing
   if (
@@ -22,6 +21,9 @@ export function onLinkHover(
     targetEl.matches('.workspace-leaf-content[data-type="calendar"] table.calendar td > div')
   )
     targetEl = targetEl.parentElement!;
+
+  const prevPopover = targetPops.has(targetEl) ? targetPops.get(targetEl) : parent.hoverPopover;
+  if (prevPopover?.lockedOut) return;
 
   const parentHasExistingPopover =
     prevPopover &&
@@ -32,8 +34,11 @@ export function onLinkHover(
     targetEl &&
     prevPopover.adopt(targetEl);
 
-  if (!parentHasExistingPopover) {
+  if (parentHasExistingPopover) {
+    targetPops.set(targetEl, prevPopover);
+  } else {
     const editor = new HoverEditor(parent, targetEl, plugin, plugin.settings.triggerDelay);
+    if (targetEl) targetPops.set(targetEl, editor);
     editor.originalLinkText = linkText;
     editor.originalPath = path;
     parent.hoverPopover = editor;

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -110,7 +110,7 @@ export class HoverEditor extends nosuper(HoverPopover) {
 
   boundOnZoomOut: () => void;
 
-  originalPath: string;  // these are kept to avoid adopting targets w/a different link
+  originalPath: string; // these are kept to avoid adopting targets w/a different link
   originalLinkText: string;
 
   static activePopovers() {

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -110,6 +110,9 @@ export class HoverEditor extends nosuper(HoverPopover) {
 
   boundOnZoomOut: () => void;
 
+  originalPath: string;  // these are kept to avoid adopting targets w/a different link
+  originalLinkText: string;
+
   static activePopovers() {
     return document.body
       .findAll(".hover-popover")


### PR DESCRIPTION
The adoption overlap thing can get a false positive when a link is wrapped across two display lines in reading mode, causing a lack of recognition of the different link target.  This PR adds link text/path checking to the adoption criteria, so there's not a false positive match.