### PR TITLE
Don't create a new leaf for a new file (Fix #114)

### DIFF
--- a/src/popover.ts
+++ b/src/popover.ts
@@ -950,10 +950,10 @@ export class HoverEditor extends nosuper(HoverPopover) {
     return tFile;
   }
 
-  async openLink(linkText: string, sourcePath: string, eState?: EphemeralState, autoCreate?: boolean) {
+  async openLink(linkText: string, sourcePath: string, eState?: EphemeralState, createInLeaf?: WorkspaceLeaf) {
     let file = this.resolveLink(linkText, sourcePath);
     const link = parseLinktext(linkText);
-    if (!file && autoCreate) {
+    if (!file && createInLeaf) {
       const folder = this.plugin.app.fileManager.getNewFileParent(sourcePath);
       file = await this.plugin.app.fileManager.createNewMarkdownFile(folder, link.path);
     }
@@ -970,7 +970,7 @@ export class HoverEditor extends nosuper(HoverPopover) {
     eState = Object.assign(this.buildEphemeralState(file, link), eState);
     const parentMode = this.getDefaultMode();
     const state = this.buildState(parentMode, eState);
-    const leaf = await this.openFile(file, state);
+    const leaf = await this.openFile(file, state, createInLeaf);
     const leafViewType = leaf?.view?.getViewType();
     if (leafViewType === "image") {
       // TODO: temporary workaround to prevent image popover from disappearing immediately when using live preview
@@ -1030,16 +1030,16 @@ export class HoverEditor extends nosuper(HoverPopover) {
         "click",
         async () => {
           this.togglePin(true);
-          await this.openLink(linkText, sourcePath, eState, true);
+          await this.openLink(linkText, sourcePath, eState, leaf);
         },
         { once: true },
       );
     }
   }
 
-  async openFile(file: TFile, openState?: OpenViewState) {
+  async openFile(file: TFile, openState?: OpenViewState, useLeaf?: WorkspaceLeaf) {
     if (this.detaching) return;
-    const leaf = this.attachLeaf();
+    const leaf = useLeaf ?? this.attachLeaf();
     this.opening = true;
     try {
       await leaf.openFile(file, openState);


### PR DESCRIPTION
This has apparently been in there for a while, guess I don't create new files from links in popovers like, well, ever.  :wink:

Btw, do we actually need to pin the popover when creating the new file?  If you're clicking the button the mouse is definitely over the popup.  And if you hover the link again the created file will pop up.  (Not that I necessarily think we *shouldn't* pin it, I'm just wondering if there's a specific reason for it.)