### PR TITLE
Preliminary multi-window support for Obsidian 0.15

### DIFF
--- a/src/PerWindowComponent.ts
+++ b/src/PerWindowComponent.ts
@@ -1,0 +1,158 @@
+import { around } from "monkey-around";
+import { Component, Plugin, View, WorkspaceLeaf } from "obsidian";
+
+/**
+ * Component that belongs to a plugin + window. e.g.:
+ *
+ *     class TitleWidget extends PerWindowComponent<MyPlugin> {
+ *         onload() {
+ *             // do stuff with this.plugin and this.win ...
+ *         }
+ *     }
+ *
+ *     class MyPlugin extends Plugin {
+ *         titleWidgets = TitleWidget.perWindow(this);
+ *         ...
+ *     }
+ *
+ * This will automatically create a title widget for each window as it's opened, and
+ * on plugin load.  The plugin's `.titleWidgets` will also be a WindowManager that can
+ * look up the title widget for a given window, leaf, or view, or return a list of
+ * all of them.  See WindowManager for the full API.
+ *
+ * If you want your components to be created on demand instead of automatically when
+ * window(s) are opened, you can pass `false` as the second argument to `perWindow()`.
+ */
+export class PerWindowComponent<P extends Plugin> extends Component {
+  constructor(public plugin: P, public win: Window) {
+    super();
+  }
+
+  static perWindow<T extends PerWindowComponent<P>, P extends Plugin>(
+    this: new (plugin: P, win: Window) => T,
+    plugin: P,
+    autocreate = true,
+  ) {
+    return new WindowManager(plugin, this, autocreate);
+  }
+}
+
+/**
+ * Manage per-window components
+ */
+export class WindowManager<T extends PerWindowComponent<P>, P extends Plugin> extends Component {
+  instances = new WeakMap<Window, T>();
+
+  constructor(
+    public plugin: P,
+    public factory: new (plugin: P, win: Window) => T, // The class of thing to manage
+    public autocreate = true, // create all items at start and monitor new window creation
+  ) {
+    super();
+    plugin.addChild(this);
+  }
+
+  onload() {
+    const { workspace } = this.plugin.app;
+    if (this.autocreate)
+      workspace.onLayoutReady(() => {
+        const self = this;
+        // Monitor new window creation
+        if (workspace.floatingSplit)
+          this.register(
+            around(workspace, {
+              openPopout(old) {
+                return function () {
+                  const popoutSplit = old.call(this);
+                  setImmediate(() => self.forWindow(popoutSplit.win));
+                  return popoutSplit;
+                };
+              },
+            }),
+          );
+        this.forAll(); // Autocreate all instances
+      });
+  }
+
+  forWindow(): T;
+  forWindow(win: Window): T;
+  forWindow(win: Window, create: true): T;
+  forWindow(win: Window, create: boolean): T | undefined;
+
+  forWindow(win: Window = window.activeWindow ?? window, create = true): T | undefined {
+    let inst = this.instances.get(win);
+    if (!inst && create) {
+      inst = new this.factory(this.plugin, win);
+      if (inst) {
+        this.instances.set(win, inst!);
+        inst.registerDomEvent(win, "beforeunload", () => {
+          this.removeChild(inst!);
+          this.instances.delete(win);
+        });
+        this.addChild(inst);
+      }
+    }
+    return inst || undefined;
+  }
+
+  forDom(el: Node): T;
+  forDom(el: Node, create: true): T;
+  forDom(el: Node, create: boolean): T | undefined;
+
+  forDom(el: Node, create = true) {
+    return this.forWindow(windowForDom(el), create);
+  }
+
+  forLeaf(leaf: WorkspaceLeaf): T;
+  forLeaf(leaf: WorkspaceLeaf, create: true): T;
+  forLeaf(leaf: WorkspaceLeaf, create: boolean): T | undefined;
+
+  forLeaf(leaf: WorkspaceLeaf, create = true) {
+    return this.forDom(leaf.containerEl, create);
+  }
+
+  forView(view: View): T;
+  forView(view: View, create: true): T;
+  forView(view: View, create: boolean): T | undefined;
+
+  forView(view: View, create = true) {
+    return this.forDom(view.containerEl, create);
+  }
+
+  windows() {
+    const windows: Window[] = [window],
+      { floatingSplit } = this.plugin.app.workspace;
+    if (floatingSplit) {
+      for (const split of floatingSplit.children) if (split.win) windows.push(split.win);
+    }
+    return windows;
+  }
+
+  forAll(create = true) {
+    return this.windows()
+      .map(win => this.forWindow(win, create))
+      .filter(t => t);
+  }
+}
+
+export function windowForDom(el: Node) {
+  return (el instanceof Document ? el : el.ownerDocument!).defaultView!;
+}
+
+declare global {
+  // Backward compatibility for single-window Obsidian (<0.15)
+  interface Window {
+    activeWindow?: Window;
+  }
+}
+
+declare module "obsidian" {
+  interface Workspace {
+    floatingSplit?: { children: { win?: Window }[] };
+    openPopout(): WorkspaceSplit;
+    openPopoutLeaf(): WorkspaceLeaf;
+  }
+  interface WorkspaceLeaf {
+    containerEl: HTMLElement;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -351,8 +351,8 @@ export default class HoverEditorPlugin extends Plugin {
   registerActivePopoverHandler() {
     this.registerEvent(
       this.app.workspace.on("active-leaf-change", leaf => {
-        document.querySelector("body > .popover.hover-popover.is-active")?.removeClass("is-active");
-        const hoverEditor = leaf ? HoverEditor.forLeaf(leaf) : undefined;
+        HoverEditor.activePopover?.hoverEl.removeClass("is-active");
+        const hoverEditor = (HoverEditor.activePopover = leaf ? HoverEditor.forLeaf(leaf) : undefined);
         if (hoverEditor && leaf) {
           hoverEditor.hoverEl.addClass("is-active");
           const titleEl = hoverEditor.hoverEl.querySelector(".popover-title");

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,7 +39,12 @@ class Interactor extends PerWindowComponent<HoverEditorPlugin> {
     return interact;
   }
 
+  onload() {
+    this.win.addEventListener("resize", this.plugin.debouncedPopoverReflow);
+  }
+
   onunload() {
+    this.win.removeEventListener("resize", this.plugin.debouncedPopoverReflow);
     this.interact.removeDocument(this.win.document);
   }
 }
@@ -53,7 +58,6 @@ export default class HoverEditorPlugin extends Plugin {
   async onload() {
     this.registerActivePopoverHandler();
     this.registerFileRenameHandler();
-    this.registerViewportResizeHandler();
     this.registerContextMenuHandler();
     this.registerCommands();
     this.patchUnresolvedGraphNodeHover();
@@ -420,15 +424,6 @@ export default class HoverEditorPlugin extends Plugin {
     100,
     true,
   );
-
-  registerViewportResizeHandler() {
-    // we can't use the native obsidian onResize event because
-    // it triggers for WAY more than just a main window resize
-    window.addEventListener("resize", this.debouncedPopoverReflow);
-    this.register(() => {
-      window.removeEventListener("resize", this.debouncedPopoverReflow);
-    });
-  }
 
   patchUnresolvedGraphNodeHover() {
     const leaf = new (WorkspaceLeaf as new (app: App) => WorkspaceLeaf)(this.app);

--- a/src/onLinkHover.ts
+++ b/src/onLinkHover.ts
@@ -58,6 +58,8 @@ export function onLinkHover(
       }
     };
 
+    const { document } = editor;
+
     // to prevent mod based keyboard shortcuts from accidentally triggering popovers
     const onKeyUp = function (event: KeyboardEvent) {
       if (!editor) return;

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -118,11 +118,24 @@ export class HoverEditor extends nosuper(HoverPopover) {
 
   static activePopover?: HoverEditor;
 
+  static activeWindows() {
+    const windows: Window[] = [window];
+    const { floatingSplit } = app.workspace;
+    if (floatingSplit) {
+      for (const split of floatingSplit.children) {
+        if (split.win) windows.push(split.win);
+      }
+    }
+    return windows;
+  }
+
   static activePopovers() {
-    return document.body
-      .findAll(".hover-popover")
-      .map(el => popovers.get(el)!)
-      .filter(he => he);
+    return this.activeWindows().flatMap(w =>
+      w.document.body
+        .findAll(".hover-popover")
+        .map(el => popovers.get(el)!)
+        .filter(he => he),
+    );
   }
 
   static forLeaf(leaf: WorkspaceLeaf | undefined) {
@@ -137,6 +150,11 @@ export class HoverEditor extends nosuper(HoverPopover) {
     }
     return false;
   }
+
+  hoverEl: HTMLElement = this.document.defaultView!.createDiv({
+    cls: "popover hover-popover",
+    attr: { id: "he" + this.id },
+  });
 
   constructor(
     parent: HoverEditorParent,
@@ -157,7 +175,7 @@ export class HoverEditor extends nosuper(HoverPopover) {
     this.parent = parent;
     this.waitTime = waitTime;
     this.state = PopoverState.Showing;
-    const hoverEl = (this.hoverEl = createDiv({ cls: "popover hover-popover", attr: { id: "he" + this.id } }));
+    const { hoverEl } = this;
     this.onMouseIn = this._onMouseIn.bind(this);
     this.onMouseOut = this._onMouseOut.bind(this);
     this.abortController!.load();
@@ -190,7 +208,7 @@ export class HoverEditor extends nosuper(HoverPopover) {
     this.containerEl = this.hoverEl.createDiv("popover-content");
     this.buildWindowControls();
     this.setInitialDimensions();
-    const pinEl = (this.pinEl = createEl("a", "popover-header-icon mod-pin-popover"));
+    const pinEl = (this.pinEl = this.document.defaultView!.createEl("a", "popover-header-icon mod-pin-popover"));
     this.titleEl.prepend(this.pinEl);
     pinEl.onclick = () => {
       this.togglePin();
@@ -368,7 +386,7 @@ export class HoverEditor extends nosuper(HoverPopover) {
   }
 
   buildWindowControls() {
-    this.titleEl = createDiv("popover-titlebar");
+    this.titleEl = this.document.defaultView!.createDiv("popover-titlebar");
     this.titleEl.createDiv("popover-title");
     const popoverActions = this.titleEl.createDiv("popover-actions");
     const hideNavBarEl = (this.hideNavBarEl = popoverActions.createEl("a", "popover-action mod-show-navbar"));

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -1,7 +1,6 @@
 import type { ActionMap } from "@interactjs/core/scope";
 import type { Modifier } from "@interactjs/modifiers/base";
 import type { Interactable, InteractEvent, Interaction, ResizeEvent } from "@interactjs/types";
-import interact from "@nothingislost/interactjs";
 import { around } from "monkey-around";
 import {
   Component,
@@ -92,6 +91,8 @@ export class HoverEditor extends nosuper(HoverPopover) {
   oldPopover = this.parent?.hoverPopover;
 
   document: Document = this.targetEl?.ownerDocument ?? window.activeDocument ?? window.document;
+
+  interactStatic = this.plugin.interact.forWindow(this.document.defaultView!).interact;
 
   constrainAspectRatio: boolean;
 
@@ -699,21 +700,21 @@ export class HoverEditor extends nosuper(HoverPopover) {
     let windowChromeHeight: number;
     const imgRatio = this.hoverEl.dataset?.imgRatio ? parseFloat(this.hoverEl.dataset?.imgRatio) : undefined;
     this.resizeModifiers = [
-      interact.modifiers.restrictEdges({
+      this.interactStatic.modifiers.restrictEdges({
         outer: viewPortBounds,
       }),
-      interact.modifiers.restrictSize({
+      this.interactStatic.modifiers.restrictSize({
         min: self.calculateMinSize.bind(this),
         max: self.calculateMaxSize.bind(this),
       }),
-      interact.modifiers.aspectRatio({
+      this.interactStatic.modifiers.aspectRatio({
         ratio: imgRatio || "preserve",
         enabled: false,
       }),
     ];
     this.dragElementRect = { top: 0, left: 1, bottom: 0, right: 0 };
     const dragModifiers = [
-      interact.modifiers.restrict({
+      this.interactStatic.modifiers.restrict({
         restriction: calculateBoundaryRestriction,
         offset: { top: 0, left: 40, bottom: 0, right: 40 },
         elementRect: this.dragElementRect,
@@ -723,7 +724,7 @@ export class HoverEditor extends nosuper(HoverPopover) {
     if (this.constrainAspectRatio && imgRatio !== undefined) {
       this.toggleConstrainAspectRatio(true, imgRatio);
     }
-    const i = interact(this.hoverEl)
+    const i = this.interactStatic(this.hoverEl)
       .preventDefault("always")
 
       .on("doubletap", this.onDoubleTap.bind(this))

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -114,6 +114,8 @@ export class HoverEditor extends nosuper(HoverPopover) {
   originalPath: string; // these are kept to avoid adopting targets w/a different link
   originalLinkText: string;
 
+  static activePopover?: HoverEditor;
+
   static activePopovers() {
     return document.body
       .findAll(".hover-popover")

--- a/src/types/obsidian.d.ts
+++ b/src/types/obsidian.d.ts
@@ -39,6 +39,10 @@ declare global {
   const i18next: {
     t(id: string): string;
   };
+  interface Window {
+    activeWindow?: Window;
+    activeDocument?: Document;
+  }
 }
 
 declare module "obsidian" {

--- a/src/utils/measure.ts
+++ b/src/utils/measure.ts
@@ -180,7 +180,7 @@ export function dragMoveListener(event: InteractEvent) {
 export const snapDirections = ["left", "right", "viewport"];
 
 export const snapActivePopover = (direction: string, checking?: boolean) => {
-  const popover = document.body.querySelector(".hover-editor.is-active");
+  const popover = HoverEditor.activePopover?.hoverEl;
   if (popover && popover instanceof HTMLElement) {
     if (!checking) {
       if (!hasStoredDimensions(popover)) {
@@ -198,7 +198,7 @@ export const snapActivePopover = (direction: string, checking?: boolean) => {
 };
 
 export const restoreActivePopover = (checking?: boolean) => {
-  const popover = document.body.querySelector(".hover-editor.is-active");
+  const popover = HoverEditor.activePopover?.hoverEl;
   if (popover && popover instanceof HTMLElement) {
     if (!checking) {
       if (hasStoredDimensions(popover)) {
@@ -212,7 +212,7 @@ export const restoreActivePopover = (checking?: boolean) => {
 };
 
 export const minimizeActivePopover = (checking?: boolean) => {
-  const popover = document.body.querySelector(".hover-editor.is-active");
+  const popover = HoverEditor.activePopover?.hoverEl;
   const he = HoverEditor.activePopovers().find(he => he.hoverEl === popover);
   if (he) {
     if (!checking) {

--- a/src/utils/measure.ts
+++ b/src/utils/measure.ts
@@ -124,13 +124,14 @@ export function dragMoveListener(event: InteractEvent) {
 
   if (this.plugin.settings.snapToEdges) {
     let offset: { top: number; left: number };
+    const document = target.ownerDocument;
 
     const insideLeftSnapTarget = event.client.x < SNAP_DISTANCE;
     const insideRightSnapTarget = event.client.x > document.body.offsetWidth - SNAP_DISTANCE;
     const insideTopSnapTarget = event.client.y < 30;
 
     if (insideLeftSnapTarget || insideRightSnapTarget || insideTopSnapTarget) {
-      offset = calculateOffsets(target.ownerDocument);
+      offset = calculateOffsets(document);
       storeDimensions(target);
     }
 

--- a/src/utils/measure.ts
+++ b/src/utils/measure.ts
@@ -4,8 +4,8 @@ import { HoverEditor } from "src/popover";
 const SNAP_DISTANCE = 10;
 const UNSNAP_THRESHOLD = 60;
 
-export function calculateOffsets() {
-  const appContainerEl = document.body.querySelector(".app-container") as HTMLElement;
+export function calculateOffsets(document: Document) {
+  const appContainerEl = document.body.querySelector(".app-container, .workspace-split") as HTMLElement;
   const leftRibbonEl = document.body.querySelector(".mod-left.workspace-ribbon") as HTMLElement;
   const titlebarHeight = appContainerEl.offsetTop;
   const ribbonWidth = document.body.hasClass("hider-ribbon") ? 0 : leftRibbonEl ? leftRibbonEl.offsetWidth : 0;
@@ -17,7 +17,7 @@ export function getOrigDimensions(el: HTMLElement) {
   const width = el.getAttribute("data-orig-width");
   const left = parseFloat(el.getAttribute("data-orig-pos-left") || "0");
   let top = parseFloat(el.getAttribute("data-orig-pos-top") || "0");
-  const titlebarHeight = calculateOffsets().top;
+  const titlebarHeight = calculateOffsets(el.ownerDocument).top;
   if (top < titlebarHeight) top = titlebarHeight;
   return { height, width, top, left };
 }
@@ -130,7 +130,7 @@ export function dragMoveListener(event: InteractEvent) {
     const insideTopSnapTarget = event.client.y < 30;
 
     if (insideLeftSnapTarget || insideRightSnapTarget || insideTopSnapTarget) {
-      offset = calculateOffsets();
+      offset = calculateOffsets(target.ownerDocument);
       storeDimensions(target);
     }
 
@@ -189,7 +189,7 @@ export const snapActivePopover = (direction: string, checking?: boolean) => {
         restoreDimentions(popover, true);
       }
       popover.removeClasses(["snap-to-left", "snap-to-right", "snap-to-viewport"]);
-      const offset = calculateOffsets();
+      const offset = calculateOffsets(popover.ownerDocument);
       snapToEdge(popover, direction, offset);
     }
     return true;


### PR DESCRIPTION
This is a draft of multi-window support for Obsidian 0.15.1+.  It currently works (mostly) except for the interactjs parts, and I suspect some of the bounding box calculations need to be fixed for secondary windows as well.

Basically, with this PR you can get hover editors in all windows, but you can't move/resize/header-double-tap the ones in secondary windows.  Unlike in the main window, the cursor also doesn't change to show move/resize options.

I tried adding code to ensure interact.addDocument() is called for every window's document (and removeDocument() on shutdown), but that did not fix the issue.  I may see if I can figure something else out later, but if you have any ideas I'd love to hear them.
