### PR TITLE
feat: pick random colors for popovers from command palette

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -563,6 +563,15 @@ export default class HoverEditorPlugin extends Plugin {
       },
     });
     this.addCommand({
+      id: "pick-random-color",
+      name: "Pick random background colors for all popovers",
+      callback: () => {
+        this.activePopovers.forEach(popover => {
+          popover.pickColor();
+        });
+      },
+    });
+    this.addCommand({
       id: "open-new-popover",
       name: "Open new Hover Editor",
       callback: () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -572,6 +572,17 @@ export default class HoverEditorPlugin extends Plugin {
       },
     });
     this.addCommand({
+      id: "pick-color-if-picked-before",
+      name: "Pick random colors for recently opened popovers",
+      callback: () => {
+        this.activePopovers.forEach(popover => {
+          if (!popover.wasPicked()) {
+            popover.pickColor();
+          }
+        });
+      },
+    });
+    this.addCommand({
       id: "open-new-popover",
       name: "Open new Hover Editor",
       callback: () => {

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -554,13 +554,13 @@ export class HoverEditor extends nosuper(HoverPopover) {
   }
 
   pickColor() {
-    const r = Math.random() * (254 - 0) + 0;
-    const g = Math.random() * (254 - 0) + 0;
-    const b = Math.random() * (254 - 0) + 0;
+  wasPicked() {
     const el = this.hoverEl.querySelector(".view-content") as HTMLElement;
     if (el?.style) {
-      el.style.backgroundColor = "rgb(" + r + "," + g + ", " + b + ")";
+      const defaultColor = window.getComputedStyle(el).backgroundColor;
+      return el.style.backgroundColor === defaultColor;
     }
+    return false;
   }
 
   transition() {


### PR DESCRIPTION
This pull request introduces three commits to improve the display of popovers in the HoverEditor.

It adds a new command "Pick random background colors for all popovers". The command assigns random background colors to all currently active popovers. This allows users to customize the appearance of popovers and easily distinguish between multiple popovers. Another command, "Pick random colors for recently opened popovers" iterates over active popovers and assigns random background colors to those popovers that have recently been opened and do not have a custom color already assigned.

Lastly, it enhances the method for generating background colors in the HoverEditor component. The code now calculates the luminance of the current text color and uses this information to generate a background color that provides sufficient contrast. This ensures that text is always easy to read, regardless of the background color.

Motivation:

I always wonder if the bouncing command was an easter egg, an intended screensaver or just a demo. I had used it when handling notes very late at night and felt that it really helped me think more visually, easily navigating these notes on a large screen. However, the background colors often turned the text unreadable due to the contrast ratio, and the constant position changes became more cumbersome as the number of files increased. So, I made these changes.

I don't know if it's a very specific use case, but since these features don't change the overall UX of the plugin, I think that maybe it's worth a pull request.