### PR TITLE
fix(popover): force leaf measure after drag to fix Canvas coordinates

### DIFF
--- a/src/popover.ts
+++ b/src/popover.ts
@@ -802,6 +802,7 @@ export class HoverEditor extends nosuper(HoverPopover) {
             if (isA(event.target, HTMLElement)) {
               event.target.removeClass("is-dragging");
             }
+            self.requestLeafMeasure();
           },
           move: dragMoveListener.bind(self),
         },


### PR DESCRIPTION
## Description
This PR fixes an issue where mouse interactions in the Canvas view would use stale coordinates after dragging the Hover Editor.

## Context
The Canvas view caches its container's bounding rect for performance. However, dragging the Hover Editor via CSS top/left modifications does not automatically trigger a resize event. This results in the Canvas using outdated coordinates for clicks and other interactions.

## Solution
I've added `self.requestLeafMeasure()` to the drag 'end' listener. This forces the view to recalculate its position and update the cache immediately after a drag operation finishes.

Thanks for the great work on this plugin!